### PR TITLE
Add build multi-platform

### DIFF
--- a/.github/workflows/build-push-stolostron.yaml
+++ b/.github/workflows/build-push-stolostron.yaml
@@ -25,7 +25,8 @@ jobs:
 
     - name: build
       run: |
-        REPOSITORY=${{env.REPOSITORY}} VERSION=${{env.VERSION_TAG}} make docker-buildx-release
+        REPOSITORY=${{env.REPOSITORY}} VERSION=${{env.VERSION_TAG}} \
+        PLATFORM="linux/amd64,linux/arm64,linux/arm/v7"  OUTPUT_TYPE=type=registry GENERATE_ATTESTATIONS=true make docker-buildx-release
 
     - name: push
       run: |


### PR DESCRIPTION
Now, this CI is built only for platform amd64. but we need to support arm64 too for dev. 