### PR TITLE
[release-3.21] no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ This project is governed by the [CNCF Code of conduct](https://github.com/cncf/f
 For details on how to report vulnerabilities and security release process, please refer to [Gatekeeper Security](https://open-policy-agent.github.io/gatekeeper/website/docs/security) for more information.
 
 <!---
-Date: 01/29/2025
+Date: 03/31/2026
 -->


### PR DESCRIPTION
3.21 is currently in a scenario where the staged releases are failing due to Konflux release behaviors. This no-op ought to resolve it to get it realigned.

Slack thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1774907132698249