### PR TITLE
[release-3.19] chore: upgrade to Go 1.26 builder to fix CVE-2025-71319

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25@sha256:977bd041377a1367c8b102a460ae8e63f89905f7cf9d8235484ae658c9b47646 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26@sha256:977bd041377a1367c8b102a460ae8e63f89905f7cf9d8235484ae658c9b47646 AS builder
 ENV LDFLAGS="-X github.com/open-policy-agent/gatekeeper/v3/pkg/version.Version=v3.19.3" \
     GO111MODULE=on \
     CGO_ENABLED=1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-policy-agent/gatekeeper/v3
 
-go 1.25.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/trace v1.10.11


### PR DESCRIPTION
## Summary

This PR addresses multiple security vulnerabilities in `stolostron/gatekeeper` release-3.19.

### CVE-2025-71319 (ACM-35924)

Upgrades the RHTAP builder image to `openshift-golang-builder:rhel_9_1.26` to address **CVE-2025-71319** — `image-size`: Denial of Service due to infinite loop when processing specially crafted images. The Go 1.26 builder ships with `image-size >= 1.2.1`.

### govulncheck findings (GO-2026-5063, GO-2026-5064, GO-2026-4887, GO-2026-4883)

Upgrades indirect dependencies flagged by `govulncheck`:

| Vulnerability | Module | From | To |
|---|---|---|---|
| GO-2026-5063 | `github.com/containerd/containerd` | v1.7.32 | v1.7.33 |
| GO-2026-5064 containerd CRI CDI annotation smuggling | `github.com/containerd/containerd` | v1.7.32 | v1.7.33 |
| GO-2026-4887 Moby AuthZ plugin bypass | `github.com/docker/docker` | v28.0.0 | v28.5.2 |
| GO-2026-4883 Moby off-by-one plugin privilege | `github.com/docker/docker` | v28.0.0 | v28.5.2 |

Note: `govulncheck` showed "Fixed in: N/A" for all four — the Go vuln DB hasn't been updated yet but the fixes are present in the upgraded versions.

## Jira

- https://redhat.atlassian.net/browse/ACM-35924

## Changes

- `build/Dockerfile.rhtap`: `openshift-golang-builder:rhel_9_1.25` → `rhel_9_1.26`
- `go.mod`: `go 1.25.0` → `go 1.26.0`, containerd v1.7.33, docker/docker v28.5.2
- `go.sum`, `vendor/`: updated accordingly