### PR TITLE
[release-3.20] chore: sync common makefiles for go 1.26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,79 +1,41 @@
 version: 2
-
 updates:
-  - package-ecosystem: "npm"
-    directory: "/website"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-    groups:
-      all:
-        patterns:
-        - "*"
-
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-        - "version-update:semver-major"
-        - "version-update:semver-minor"
-    groups:
-      k8s:
-        patterns:
-        - "k8s.io/*"
-        - "sigs.k8s.io/*"
-
-  - package-ecosystem: "docker"
+  - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-
-  - package-ecosystem: "docker"
-    directory: "/build/tooling"
+      interval: cron
+      cronjob: "0 7 * * MON#1"
+      timezone: America/New_York
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 14
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: gomod
+    directory: /
     schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-
-  - package-ecosystem: "docker"
-    directory: "/test/externaldata/dummy-provider"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-
-  - package-ecosystem: "docker"
-    directory: "/test/image"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-
-  - package-ecosystem: "docker"
-    directory: "/test/export/fake-subscriber"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-
-  - package-ecosystem: "docker"
-    directory: "/test/export/fake-reader"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
+      interval: cron
+      cronjob: "0 7 * * MON#1"
+      timezone: America/New_York
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 14
+    groups:
+      gomod:
+        patterns:
+          - "*"
+    allow:
+      - dependency-type: all
+    ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      - dependency-name: "*.k8s.io/*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
ref: https://redhat.atlassian.net/browse/ACM-35531